### PR TITLE
Refactor names, add FileIndexer

### DIFF
--- a/fractionalindex/__init__.py
+++ b/fractionalindex/__init__.py
@@ -1,1 +1,4 @@
-__all__ = ["FractionalIndex","FileIndex","SqliteIndex"]
+from .fractionalindex import SqliteIndexer, FileIndexer
+
+__all__ = ["SqliteIndexer","FileIndexer"]
+           

--- a/fractionalindex/fractionalindex.py
+++ b/fractionalindex/fractionalindex.py
@@ -1,88 +1,48 @@
+from pathlib import Path
 from sortedcontainers import SortedList
 from fractional_indexing import generate_key_between
 from fastcore.utils import *
 
-class IndexingList(SortedList):
-    "A subclass of SortedList that adds methods for finding the next/previous items and the first/last items in the list."
-    def after(self, item):
-        "Returns the next item after the specified item, or None if there is none."
-        i = self.bisect_right(item)
-        return self[i] if i<len(self) else None
+class Indexer:
+    """
+    An Indexer provides insert() and friends, which generate a fractional index KEY to be used when adding a new item.
 
-    def before(self, item): 
-        "Returns the previous item before the specified item, or None if there is none."
-        i = self.bisect_left(item)-1
-        return self[i] if i>=0 else None
+    Generally, an indexer does not modify the resource. The method is called "insert" but the indexer is only generating a key.
 
-    def begin(self):
-        "Returns the first item in the list, or None if empty."
-        return self[0] if self else None
-
-    def end(self):
-        "Returns the last item in the list, or None if empty."
-        return self[-1] if self else None
-
-class FractionalIndexBase:
-    "Manages a sorted list of version strings and allows inserting new versions between existing ones."
+    The user might choose to add the item with a NAME derived from the KEY.
+    """
     def __init__(self,
-                 items=None, # Optional list of version strings to initialize with
-                 idxlist=None # Optional IndexingList to initialize with
+                 accessor,                # provides index accessors for the resource
+                 name_to_key = lambda x:x # maps resource item NAMEs to KEYs
                  ):
-        self.items = idxlist or IndexingList(items or [])
+        self.items = accessor
+        self.name_to_key = name_to_key
 
     def insert(self,
-               after=None, # Item to insert after
-               before=None # Item to insert before
+               after=None, # NAME to insert after
+               before=None # NAME to insert before
                ):
-        """Insert a new item between the specified items.
-        
-        If only after is specified, inserts after that item but before the next item.
-        If only before is specified, inserts before that item but after the previous item.
-        If neither is specified, adds to the end."""
-        if after and not before: before = self.items.after(after)
-        elif before and not after: after = self.items.before(before)
-        elif not after and not before: after = self.items.end()
-        return self.add(generate_key_between(after, before))
+        match (after, before):
+            case (None, None):  after  = self.items.last()
+            case (None, _):     after  = self.items.before(before)
+            case (_, None):     before = self.items.after(after)
+        return generate_key_between(self.name_to_key(after), self.name_to_key(before))
+    
+    def insert_at_start(self): return self.insert(before=self.items.first())
+    def insert_at_end(self): return self.insert(after=self.items.last())
+    def __iter__(self):
+        current = self.items.first()
+        while current is not None:
+            yield current
+            current = self.items.after(current)
 
-    def begin(self):
-        "Insert a new item at the start of the list."
-        b = self.items.begin()
-        return self.add(generate_key_between(None, b))
+## External resource: SQLITE
 
-    def add(self, item):
-        "Add a new item to the list."
-        return item
+"""
+The Accessor methods after(),before(),first(),last() provide readonly access to the NAMEs of items in a resource.
+"""
 
-
-class FractionalIndex(FractionalIndexBase):
-    def add(self, item):
-        self.items.add(item)
-        return item
-
-    def __getitem__(self, i): return self.items[i]
-    def __len__(self): return len(self.items)
-
-
-class FileIndexing:
-    def __init__(self,
-                 dir=".", # Directory to scan for files
-                 sep="-" # Separator between version and rest of filename 
-                 ):
-        store_attr()
-
-    def _list(self): return IndexingList([f.name.split(self.sep)[0] for f in Path(self.dir).iterdir()])
-    def after(self, item): return self._list().after(item)
-    def before(self, item): return self._list().before(item)
-    def begin(self): return self._list().begin()
-    def end(self): return self._list().end()
-
-
-class FileIndex(FractionalIndexBase):
-    def __init__(self, dir=".", sep="-"):
-        idxlist = FileIndexing(dir, sep)
-        super().__init__(idxlist=idxlist)
-
-class SqliteIndexing:
+class SqliteAccessor:
     def __init__(self,
                  conn, # sqlite3 connection 
                  table, # table name
@@ -96,11 +56,117 @@ class SqliteIndexing:
         r = self.conn.execute(q, params).fetchone()
         return r[0] if r else None
 
-    def after(self, item): return self.fetchone('min', f"{self.col}>?", (item,))
+    def first(self): return self.fetchone('min')
+    def last(self): return self.fetchone('max')
     def before(self, item): return self.fetchone('max', f"{self.col}<?", (item,))
-    def begin(self): return self.fetchone('min')
-    def end(self): return self.fetchone('max')
+    def after(self, item): return self.fetchone('min', f"{self.col}>?", (item,))
 
+#
+# The following methods would be neded intead, to support
+# users accessing before/after information restricted
+# to a part of the table via additional conditions in the where clause
 
-class SqliteIndex(FractionalIndexBase):
-    def __init__(self, conn, table, col='id'): super().__init__(idxlist=SqliteIndexing(conn, table, col))
+    # def after(self, name, extra_where_condition=None):
+    #     cond,vars = f"{self.col}>?", (name,)
+    #     if extra_where_condition is not None:
+    #         (sqlcond,value) = extra_where_condition
+    #         cond += f' AND {sqlcond}'
+    #         vars = tuple(list(vars) + [value])
+    #     return self.fetchone('min', cond, vars)
+
+    # def before(self, name, extra_where_condition=None):
+    #     cond,vars = f"{self.col}<?", (name,)
+    #     if extra_where_condition is not None:
+    #         (sqlcond,value) = extra_where_condition
+    #         cond += f' AND {sqlcond}'
+    #         vars = tuple(list(vars) + [value])
+    #     return self.fetchone('max', cond, vars)
+
+class SqliteIndexer(Indexer):
+    def __init__(self, 
+                 conn, 
+                 table, 
+                 col='id',
+                 name_to_key=lambda x:x # mapping which preserves key ordering
+                 ):
+        super().__init__(accessor=SqliteAccessor(conn, table, col),
+                         name_to_key=name_to_key)
+
+## Managed resource: a Python list
+
+class ManagedListIndexer(Indexer):
+    "Indexer which unusually owns and manages its resource, a Python list. Mainly, an implementation helper"
+    def __init__(self,keys=[]):
+        self.lst = ManagedListAccessor(keys)
+        super().__init__(self.lst)
+    def insert(self,after=None,before=None):
+        new_idx = super().insert(after=after,before=before)
+        self.lst.add(new_idx)
+        return new_idx
+    def __getitem__(self,key): return self.lst[key]
+    def __len__(self): return len(self.lst)
+
+class ManagedListAccessor(SortedList):
+    "An accessor which, unusually, owns and manages its resource, a sorted Python list."
+    def after(self, item):
+        "Returns the next item after the specified item, or None if there is none."
+        i = self.bisect_right(item)
+        return self[i] if i<len(self) else None
+
+    def before(self, item): 
+        "Returns the previous item before the specified item, or None if there is none."
+        i = self.bisect_left(item)-1
+        return self[i] if i>=0 else None
+
+    def first(self):
+        "Returns the first item in the list, or None if empty."
+        return self[0] if self else None
+
+    def last(self):
+        "Returns the last item in the list, or None if empty."
+        return self[-1] if self else None
+
+## External resouce: a directory of files
+
+class FileAccessor:
+    def __init__(self,
+                 dir=".",               # Directory to scan for files
+                 name_to_key=lambda x:x # Returns key given a valid file name. Else, None
+                 ):
+        self.name_to_key=name_to_key
+        store_attr()
+
+    def _key_names(self):
+        "maps keys to valid file names in dir"
+        retval = dict()
+        names = [f.name for f in Path(self.dir).iterdir()]
+        for name in names:
+            key = self.name_to_key(name)
+            if key is not None:
+                retval[key] = name
+        return retval
+
+    def _keys(self): return ManagedListAccessor(self._key_names().keys())
+    def _k_to_n(self,k): return None if k is None else self._key_names()[k]
+    def _n_to_f_to_n(self,f,n): return self._k_to_n( f(n) )
+    
+    def after(self, name):
+        in_k = self.name_to_key(name)
+        out_k = self._keys().after(in_k)
+        return None if out_k is None else self._key_names()[out_k]
+    def before(self, name):
+        in_k = self.name_to_key(name)
+        out_k = self._keys().before(in_k)
+        return None if out_k is None else self._key_names()[out_k]    
+    def first(self):
+        in_k = self._keys().first()
+        return None if in_k is None else self._key_names()[in_k]
+    def last(self):
+        in_k = self._keys().last()
+        return None if in_k is None else self._key_names()[in_k]
+    
+class FileIndexer(Indexer):
+    def __init__(self, dir=".", name_to_key=lambda x:x):
+        accessor = FileAccessor(dir, name_to_key)
+        super().__init__(accessor=accessor, name_to_key=name_to_key)
+

--- a/notes_fractionalindexing.ipynb
+++ b/notes_fractionalindexing.ipynb
@@ -1,0 +1,366 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6441a697",
+   "metadata": {},
+   "source": [
+    "# FractionalIndex\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df182ab9",
+   "metadata": {},
+   "source": [
+    "This library helps with using fractional indexes to manage a collection of items, like a sqlite table or a directory of files.\n",
+    "\n",
+    "What's a fractional index and why would you want it? Fractional indexes are _values_ designed to solve a particular problem: they let you manage an ordering over a set of items, via a key value for each item, in such a way that you can add a new item in between existing items without needing to update any item's key, and you can re-order a single item by updating only its key.\n",
+    "\n",
+    "This is useful in situations where you need item keys to be stable because it expensive to update them or because other systems depend on them.\n",
+    "\n",
+    "This library helps with two particular kinds of collections: rows in an sqlite table, or files in a directory.\n",
+    "\n",
+    "The library works by providing an  **indexer**. The indexer treats the collection of items as an **external resource**. It reads the resource, but never modifies it. You the user are responsible for adding items to the collection. Whenever you add an item, you get the **key** to use for the item from the indexer.\n",
+    "\n",
+    "## Example: sqlite, where a column holds a key\n",
+    "\n",
+    "For instance, say you wanted to insert a new row in the table `mytable` in sqlite, but you wanted to give it a key so that it would appear in between two existing rows, which have values `a0` and `b0` in the column `order_key`.\n",
+    "\n",
+    "You'd do it like so:\n",
+    "\n",
+    "```python\n",
+    "from fractionalindex import SqliteIndexer\n",
+    "\n",
+    "# init an indexer\n",
+    "sqliteindexer = SqliteIndexer(conn,'mytable', 'order_key')\n",
+    "# generate a new key between existing, adjoining keys\n",
+    "new_key = sqliteindexer.insert('a0','b0')\n",
+    "# insert the row\n",
+    "conn.execute(f'INSERT INTO mytable (order_key) VALUES (?)', (new_key,))\n",
+    "```\n",
+    "\n",
+    "## Example: sqlite, where a column holds a key-derived name\n",
+    "\n",
+    "The indexer's `insert()` method returns the key which is used for fractional indexing.\n",
+    "\n",
+    "However, in your sqlite database, you might not want to use raw key values (like \"a0\") but instead prefer to use a **name** derived from a key, like \"msg-a0\".\n",
+    "\n",
+    "To do this, pass the **name-to-key** to the indexer, and construct the name yourself when adding an item to the db:\n",
+    "\n",
+    "```python\n",
+    "def name_to_key(name): \n",
+    "    return name.split('-')[1] if (name is not None and '-' in name) else None\n",
+    "# init an indexer\n",
+    "sqliteindexer = SqliteIndexer(conn,'mytable', 'order_key',name_to_key)\n",
+    "# generate a new key between existing, adjoining keys\n",
+    "new_key = sqliteindexer.insert('msg-a0','msg-b0')\n",
+    "new_name = f\"msg-{new_key}\"\n",
+    "# insert the row\n",
+    "conn.execute(f'INSERT INTO mytable (order_key) VALUES (?)', (new_name,))\n",
+    "```\n",
+    "\n",
+    "For sqlite, the library requires that the name ordering matches the key ordering, which will be the case with a constant prefix. But this is not required for the next example:\n",
+    "\n",
+    "\n",
+    "## Example: files, with names derived from keys\n",
+    "\n",
+    "You can also use the library to define an ordering over a directory of files, like migration scripts.\n",
+    "\n",
+    "Let's say you want script to have names like  `foo-a0.txt`, where `a0` is the key part. Then you'd define this name-to-key mapping function:\n",
+    "\n",
+    "```python\n",
+    "def get_filekey(name):\n",
+    "    return name.sep(\".\")[0].sep(\"-\")[1]\n",
+    "```\n",
+    "\n",
+    "With this function defined, you could create a `FileIndexer` over the files in the current directory like so:\n",
+    "\n",
+    "```python\n",
+    "from fractionalindex import FileIndexer\n",
+    "\n",
+    "nfi = NamedFileIndexer(dir='.', name_to_key=get_filekey) # init the indexer\n",
+    "```\n",
+    "\n",
+    "And you'd add a new file between the existing files \"myfile-a0.txt\" and \"update-b0.txt\", like so:\n",
+    "\n",
+    "```python\n",
+    "newfile_key = nfi.insert(after=\"myfile-a0.txt\",\n",
+    "                         before=\"update-b0.txt\") # generate the new key\n",
+    "newfile_name = f\"myfile-{newfile_key}\"           # create the file name\n",
+    "Path(newfile_name).touch()                       # add a file to the directory\n",
+    "```\n",
+    "\n",
+    "As with the database example, you are responsible creating the file. The indexer just provides the key to use in naming it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf6e245f",
+   "metadata": {},
+   "source": [
+    "## Extending to other resources\n",
+    "\n",
+    "If you want to extend this library to create a new kind of indexer, the working model to keep in mind is fairly simple:\n",
+    "\n",
+    "- the **Indexer** holds a reference to a **collection resource**, but does not modify it. \n",
+    "- in the collection of items, every item has a **name**\n",
+    "- The indexer takes those names, and generates **keys**.\n",
+    "- internally, for each resource type, an **IndexAccessor** provides the first(), last(), before(), and after() accessors, which take names and return names\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3d91f0b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4929f54",
+   "metadata": {},
+   "source": [
+    "## fractional_indexing\n",
+    "\n",
+    "This is a review of the underlying dependency library, used for generating fractional indexes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "449fd860",
+   "metadata": {},
+   "source": [
+    "To review, the `fractional-indexing` pypi package provides primitives for generating and validating keys. The key-generating function takes two params, which are interpreted a bit like the components of a slice, in designating either zone between two existing indexes, or else defining the zone before or after an index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d01b43c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fractional_indexing import generate_key_between\n",
+    "first = generate_key_between(None,None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "893d87a4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'a0'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "first"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0603cf01",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'a1'"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "second = generate_key_between(first,None)\n",
+    "second"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ed188089",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'a2'"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "third = generate_key_between(second,None)\n",
+    "third"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d029975c",
+   "metadata": {},
+   "source": [
+    "The keys are strings and their lexicographic sort order is their index order:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7727f4d6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[first,second,third] == sorted([first,second,third])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56fec49a",
+   "metadata": {},
+   "source": [
+    "**Q: What about ambiguous specifications?** Like asking for a key between second-third vs simply after second?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "3ca16f55",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'a1V'"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "generate_key_between(second,third)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "289b4ca2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'a2'"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "generate_key_between(second,None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a705b846",
+   "metadata": {},
+   "source": [
+    "**Note regarding state**: The library is not managing a stateful collection of the keys which have been created. It only defining how one key values depend on each other. So generating repeatedly will always produce the same value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "f1b69640",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[generate_key_between(second,None) for _ in range(10)][0]  == generate_key_between(second,None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "84f65ee5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['a0', 'a1', 'a2']"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[first,second,third]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_fractionalindex.py
+++ b/tests/test_fractionalindex.py
@@ -1,10 +1,11 @@
 from fastcore.utils import *
 import sqlite3, tempfile
 from pathlib import Path
-from fractionalindex.fractionalindex import FractionalIndex, FileIndex, SqliteIndex
+from fractionalindex.fractionalindex import *
 
-def test_fractional_index_basic():
-    idx = FractionalIndex()
+
+def test_managed_list_indexer():
+    idx = ManagedListIndexer()
     i1 = idx.insert()
     assert i1.startswith('a')
     i2 = idx.insert(after=i1)
@@ -17,54 +18,112 @@ def test_fractional_index_basic():
     lst = list(idx.items)
     assert i5 in lst and i5>i2
     assert len(lst)==5
-    i6 = idx.begin()
+    i6 = idx.insert_at_start()
     assert i6<i1
     assert idx.items == [i6, i1, i3, i4, i2, i5]
 
-def _test_index(idx, nms, add_func=noop):
-    i1 = idx.begin()
-    assert i1<nms[0]
+def _test_indexer(idx,
+                  add_func=noop # takes a key, creates the item, returns its name 
+                  ):
+    i1 = idx.insert()
+    i1name = add_func(i1)
+    assert i1.startswith('a')
+
+    i2 = idx.insert(after=i1name)
+    i2name = add_func(i2)
+    assert i2>i1
+
+    i3 = idx.insert(before=i2name)
+    i3name = add_func(i3)
+    assert i1<i3 
+    assert i3<i2
+
+    i4 = idx.insert(i3name, i2name)
+    i4name = add_func(i4)
+    assert i4>i3 and i4<i2
+
+    i5 = idx.insert()
+    i5name = add_func(i5)
+    assert i5>i2
+    lst = list(idx) #
+    assert len(lst)==5
+
+    i6 = idx.insert_at_start()
+    i6name = add_func(i6)
+    assert i6<i1
+    assert list(idx) == [i6name, i1name, i3name, i4name, i2name, i5name]
+
+def test_named_file_indexer():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        d = Path(tmpdir)
+        def add_file(key): 
+            name = f'{key}--a' 
+            (d/name).touch()
+            return name
+        def get_key_from_name(name):
+            if name is not None and '--' in name: return name.split('--')[0]
+            else: return None
+        idx = FileIndexer(d,get_key_from_name)
+        _test_indexer(idx, add_file)
+
+def test_sqlite_indexer():
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE test (id TEXT PRIMARY KEY)")
+    idx = SqliteIndexer(conn, table='test', col='id')
+    def name_to_key(name): return name
+    def add_record(key):
+        conn.execute("INSERT INTO test (id) VALUES (?)", (key,))
+        return key
+    _test_indexer(idx, add_record)
+
+def test_sqlite_indexer_with_names():
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE test (id TEXT PRIMARY KEY)")
+    def name_to_key(name): 
+        return name.split('-')[1] if (name is not None and '-' in name) else None
+    idx = SqliteIndexer(conn, table='test', col='id',name_to_key=name_to_key)
+    def add_record(key):
+        name = f"msg-{key}"
+        conn.execute("INSERT INTO test (id) VALUES (?)", (name,))
+        return name
+    _test_indexer(idx, add_record)
+
+def test_managed_list():
+    "Initializing a managed list indexer with a list"
+    nms = ['a2', 'a0', 'a1'] # out of order
+    idx = ManagedListIndexer(nms)
+    nms.sort()
+    assert list(idx)==nms
+    _test_indexer_with_initial_names(idx, nms)
+
+
+def _test_indexer_with_initial_names(idx, initial_names, add_func=noop):
+    "Tests any Indexer, assuming the resource starts with initial_names"
+    i1 = idx.insert_at_start()
+    assert i1<initial_names[0]
     add_func(i1)
-    i2 = idx.insert()
-    assert i2>nms[-1]
+    i2 = idx.insert_at_end()
+    assert i2>initial_names[-1]
     add_func(i2)
     i3 = idx.insert(before=i2)
-    assert i3<i2 and i3>nms[-1]
+    assert i3<i2 and i3>initial_names[-1]
     add_func(i3)
-    i4 = idx.insert(after=nms[0])
-    assert i4>nms[0] and i4<nms[1] 
+    i4 = idx.insert(after=initial_names[0])
+    assert i4>initial_names[0] and i4<initial_names[1] 
     add_func(i4)
-    i5 = idx.insert(before=nms[1])
-    assert i5>nms[0] and i5<nms[1]
+    i5 = idx.insert(before=initial_names[1])
+    assert i5>initial_names[0] and i5<initial_names[1]
     add_func(i5)
     i6 = idx.insert(i4, i5)
     assert i6>i4 and i6<i5
     add_func(i6)
-    i7 = idx.insert(nms[1], nms[2])
-    assert i7>nms[1] and i7<nms[2]
+    i7 = idx.insert(initial_names[1], initial_names[2])
+    assert i7>initial_names[1] and i7<initial_names[2]
     add_func(i7)
 
-def test_fractional_index():
-    nms = ['a2', 'a0', 'a1']
-    idx = FractionalIndex(nms)
-    nms.sort()
-    assert idx.items==nms
-    _test_index(idx, nms)
+def test_managed_list_with_initial_names():
+    "Initializing a managed list indexer with a list"
+    nms = ['a2', 'a0', 'a1'] # out of order
+    idx = ManagedListIndexer(nms)
+    _test_indexer_with_initial_names(idx, sorted(nms))
 
-def test_file_index():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        d = Path(tmpdir)
-        def add_file(nm): (d/f'{nm}-a').touch()
-        nms = ['a0-create.sql','a1-update.sql','a2-index.sql']
-        for nm in nms: (d/nm).touch()
-        idx = FileIndex(d, sep='-')
-        _test_index(idx, [o.split('-')[0] for o in nms], add_file)
-
-def test_sqlite_index():
-    conn = sqlite3.connect(":memory:")
-    conn.execute("CREATE TABLE test (id TEXT PRIMARY KEY)")
-    rows = [('Zz',),('a0',),('a1',)]
-    conn.executemany("INSERT INTO test (id) VALUES (?)", rows)
-    idx = SqliteIndex(conn, 'test', 'id')
-    def add_row(i): conn.execute(f"INSERT INTO test (id) VALUES (?)", (i,))
-    _test_index(idx, [o[0] for o in rows], add_row)


### PR DESCRIPTION
Refactors names in the library:
- to distinguish Indexer from Accessor
- to distinguish KEYs from derived NAMEs
- to distinguish external vs internal collections

Adds a FileIndexer, which supports applying fractional indexing to a component of a filename, defined by an arbitrary user-supplied name-to-key mapping function.

SqliteIndexer also supports a name-to-key-mapping implicitly, so long as key ordering predicts name ordering.

added import statement to __init__.py, so that
the top-level module can access the symbols it
export